### PR TITLE
Cleanup and switches to native crypto

### DIFF
--- a/lib/getUrlsFromCrawler.js
+++ b/lib/getUrlsFromCrawler.js
@@ -3,7 +3,6 @@
 module.exports = (url, cacheTime) => {
   return new Promise(async function (resolve, reject) {
     try {
-      const fs         = require('fs');
       const path       = require('path');
       const clc        = require('cli-color');
       const flat_cache = require('flat-cache');
@@ -68,7 +67,7 @@ module.exports = (url, cacheTime) => {
        */
       /*
       var errors = [];
-
+      
       crawler.on("invaliddomain", (queueItem) => {
             errors.push("Ignored Domain: " + queueItem.url);
           })

--- a/lib/getUrlsFromCrawler.js
+++ b/lib/getUrlsFromCrawler.js
@@ -68,7 +68,7 @@ module.exports = (url, cacheTime) => {
        */
       /*
       var errors = [];
-      
+
       crawler.on("invaliddomain", (queueItem) => {
             errors.push("Ignored Domain: " + queueItem.url);
           })

--- a/lib/getUrlsFromCrawler.js
+++ b/lib/getUrlsFromCrawler.js
@@ -29,7 +29,6 @@ module.exports = (url, cacheTime) => {
       }
 
       var urls = [];
-      var errors = [];
       var crawler = Crawler(url);
 
       /*
@@ -68,6 +67,8 @@ module.exports = (url, cacheTime) => {
       it becomes useful later.
        */
       /*
+      var errors = [];
+      
       crawler.on("invaliddomain", (queueItem) => {
             errors.push("Ignored Domain: " + queueItem.url);
           })

--- a/package-lock.json
+++ b/package-lock.json
@@ -114,11 +114,6 @@
       "resolved": "https://registry.npmjs.org/core-util-is/-/core-util-is-1.0.2.tgz",
       "integrity": "sha1-tf1UIgqivFq1eqtxQMlAdUUDwac="
     },
-    "crypto": {
-      "version": "1.0.1",
-      "resolved": "https://registry.npmjs.org/crypto/-/crypto-1.0.1.tgz",
-      "integrity": "sha512-VxBKmeNcqQdiUQUW2Tzq0t377b54N2bMtXO/qiLa+6eRRmmC4qT3D4OnTGoT/U6O9aklQ/jTwbOtRMTTY8G0Ig=="
-    },
     "d": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/d/-/d-1.0.0.tgz",

--- a/package.json
+++ b/package.json
@@ -14,7 +14,6 @@
   },
   "dependencies": {
     "cli-color": "1.4.0",
-    "crypto": "1.0.1",
     "fast-xml-parser": "3.12.13",
     "flat-cache": "2.0.1",
     "html-validator": "3.1.3",


### PR DESCRIPTION
The `crypto` module is deprecated so I replaced it with nodes native crypto.

Removed unused dependency `fs` (used by previous crawler)

Moved te error variable inside commented block (only used with that code)