### PR TITLE
Fixed txt parsing on Windows

### DIFF
--- a/index.js
+++ b/index.js
@@ -182,10 +182,10 @@ Main Process
       }
     } else {
       if (pagesFail.length === 0) {
-        console.log('\n' + greenOnBlack('Site Validated') + ` No problems were found for ${options.url}`)
+        console.log('\n' + greenOnBlack('Site Validated') + ` No problems were found for ${options.file || options.url}`)
       } else {
         console.log('\n' + redOnBlack('Site Failed Validation') +
-        ` ${pagesFail.length} out of ${pagesTotal} pages failed validation for ${options.url}:\n`)
+        ` ${pagesFail.length} out of ${pagesTotal} pages failed validation for ${options.file || options.url}:\n`)
         pagesFail.forEach((e) => { console.log(e) })
       }
       console.log(cyanOnBlack('\nFinished Checking, have an A-1 Day!') + ' \n')

--- a/index.js
+++ b/index.js
@@ -158,12 +158,20 @@ Main Process
           printResult(JSON.parse(cacheOld.data))
         } else {
           console.log('\nPage validation cache not available, revalidating...')
-          let result = await getResult(pageUrl)
-          printResult(JSON.parse(result))
+          try {
+            let result = await getResult(pageUrl)
+            printResult(JSON.parse(result))
+          } catch (error) {
+            console.log(redOnBlack(error) + ` ${pageUrl}`)
+          }
         }
       } else {
-        let result = await getResult(pageUrl)
-        printResult(JSON.parse(result))
+        try {
+          let result = await getResult(pageUrl)
+          printResult(JSON.parse(result))
+        } catch (error) {
+          console.log(redOnBlack(error) + ` ${pageUrl}`)
+        }
       }
       console.log('__________________________________')
       if (options.failfast && pagesFail.length > 0) {

--- a/lib/get-urls-from-file.js
+++ b/lib/get-urls-from-file.js
@@ -4,5 +4,5 @@ module.exports = path => {
   const fileType = path.toLowerCase().split('.').pop()
   const data = readFileSync(path, 'utf-8').toString()
   console.log(`\nGot urls from the ${fileType} file at ${path}`)
-  return fileType === 'json' ? JSON.parse(data) : data.split('\n')
+  return fileType === 'json' ? JSON.parse(data) : data.split(/\r?\n/)
 }

--- a/lib/get-urls-from-file.js
+++ b/lib/get-urls-from-file.js
@@ -4,5 +4,5 @@ module.exports = path => {
   const fileType = path.toLowerCase().split('.').pop()
   const data = readFileSync(path, 'utf-8').toString()
   console.log(`\nGot urls from the ${fileType} file at ${path}`)
-  return fileType === 'json' ? JSON.parse(data) : data.split(/\r?\n/)
+  return fileType === 'json' ? JSON.parse(data) : data.split('\n')
 }

--- a/package-lock.json
+++ b/package-lock.json
@@ -2564,15 +2564,13 @@
           "version": "1.0.0",
           "resolved": "https://registry.npmjs.org/balanced-match/-/balanced-match-1.0.0.tgz",
           "integrity": "sha1-ibTRmasr7kneFk6gK4nORi1xt2c=",
-          "dev": true,
-          "optional": true
+          "dev": true
         },
         "brace-expansion": {
           "version": "1.1.11",
           "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.11.tgz",
           "integrity": "sha512-iCuPHDFgrHX7H2vEI/5xpz07zSHB00TpugqhmYtVmMO6518mCuRMoOYFldEBl0g187ufozdaHgWKcYFb61qGiA==",
           "dev": true,
-          "optional": true,
           "requires": {
             "balanced-match": "^1.0.0",
             "concat-map": "0.0.1"
@@ -2589,22 +2587,19 @@
           "version": "1.1.0",
           "resolved": "https://registry.npmjs.org/code-point-at/-/code-point-at-1.1.0.tgz",
           "integrity": "sha1-DQcLTQQ6W+ozovGkDi7bPZpMz3c=",
-          "dev": true,
-          "optional": true
+          "dev": true
         },
         "concat-map": {
           "version": "0.0.1",
           "resolved": "https://registry.npmjs.org/concat-map/-/concat-map-0.0.1.tgz",
           "integrity": "sha1-2Klr13/Wjfd5OnMDajug1UBdR3s=",
-          "dev": true,
-          "optional": true
+          "dev": true
         },
         "console-control-strings": {
           "version": "1.1.0",
           "resolved": "https://registry.npmjs.org/console-control-strings/-/console-control-strings-1.1.0.tgz",
           "integrity": "sha1-PXz0Rk22RG6mRL9LOVB/mFEAjo4=",
-          "dev": true,
-          "optional": true
+          "dev": true
         },
         "core-util-is": {
           "version": "1.0.2",
@@ -2735,8 +2730,7 @@
           "version": "2.0.3",
           "resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.3.tgz",
           "integrity": "sha1-Yzwsg+PaQqUC9SRmAiSA9CCCYd4=",
-          "dev": true,
-          "optional": true
+          "dev": true
         },
         "ini": {
           "version": "1.3.5",
@@ -2750,7 +2744,6 @@
           "resolved": "https://registry.npmjs.org/is-fullwidth-code-point/-/is-fullwidth-code-point-1.0.0.tgz",
           "integrity": "sha1-754xOG8DGn8NZDr4L95QxFfvAMs=",
           "dev": true,
-          "optional": true,
           "requires": {
             "number-is-nan": "^1.0.0"
           }
@@ -2767,7 +2760,6 @@
           "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-3.0.4.tgz",
           "integrity": "sha512-yJHVQEhyqPLUTgt9B83PXu6W3rx4MvvHvSUvToogpwoGDOUQ+yDrR0HRot+yOCdCO7u4hX3pWft6kWBBcqh0UA==",
           "dev": true,
-          "optional": true,
           "requires": {
             "brace-expansion": "^1.1.7"
           }
@@ -2891,8 +2883,7 @@
           "version": "1.0.1",
           "resolved": "https://registry.npmjs.org/number-is-nan/-/number-is-nan-1.0.1.tgz",
           "integrity": "sha1-CXtgK1NCKlIsGvuHkDGDNpQaAR0=",
-          "dev": true,
-          "optional": true
+          "dev": true
         },
         "object-assign": {
           "version": "4.1.1",
@@ -3043,7 +3034,6 @@
           "resolved": "https://registry.npmjs.org/string-width/-/string-width-1.0.2.tgz",
           "integrity": "sha1-EYvfW4zcUaKn5w0hHgfisLmxB9M=",
           "dev": true,
-          "optional": true,
           "requires": {
             "code-point-at": "^1.0.0",
             "is-fullwidth-code-point": "^1.0.0",

--- a/package-lock.json
+++ b/package-lock.json
@@ -2564,13 +2564,15 @@
           "version": "1.0.0",
           "resolved": "https://registry.npmjs.org/balanced-match/-/balanced-match-1.0.0.tgz",
           "integrity": "sha1-ibTRmasr7kneFk6gK4nORi1xt2c=",
-          "dev": true
+          "dev": true,
+          "optional": true
         },
         "brace-expansion": {
           "version": "1.1.11",
           "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.11.tgz",
           "integrity": "sha512-iCuPHDFgrHX7H2vEI/5xpz07zSHB00TpugqhmYtVmMO6518mCuRMoOYFldEBl0g187ufozdaHgWKcYFb61qGiA==",
           "dev": true,
+          "optional": true,
           "requires": {
             "balanced-match": "^1.0.0",
             "concat-map": "0.0.1"
@@ -2587,19 +2589,22 @@
           "version": "1.1.0",
           "resolved": "https://registry.npmjs.org/code-point-at/-/code-point-at-1.1.0.tgz",
           "integrity": "sha1-DQcLTQQ6W+ozovGkDi7bPZpMz3c=",
-          "dev": true
+          "dev": true,
+          "optional": true
         },
         "concat-map": {
           "version": "0.0.1",
           "resolved": "https://registry.npmjs.org/concat-map/-/concat-map-0.0.1.tgz",
           "integrity": "sha1-2Klr13/Wjfd5OnMDajug1UBdR3s=",
-          "dev": true
+          "dev": true,
+          "optional": true
         },
         "console-control-strings": {
           "version": "1.1.0",
           "resolved": "https://registry.npmjs.org/console-control-strings/-/console-control-strings-1.1.0.tgz",
           "integrity": "sha1-PXz0Rk22RG6mRL9LOVB/mFEAjo4=",
-          "dev": true
+          "dev": true,
+          "optional": true
         },
         "core-util-is": {
           "version": "1.0.2",
@@ -2730,7 +2735,8 @@
           "version": "2.0.3",
           "resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.3.tgz",
           "integrity": "sha1-Yzwsg+PaQqUC9SRmAiSA9CCCYd4=",
-          "dev": true
+          "dev": true,
+          "optional": true
         },
         "ini": {
           "version": "1.3.5",
@@ -2744,6 +2750,7 @@
           "resolved": "https://registry.npmjs.org/is-fullwidth-code-point/-/is-fullwidth-code-point-1.0.0.tgz",
           "integrity": "sha1-754xOG8DGn8NZDr4L95QxFfvAMs=",
           "dev": true,
+          "optional": true,
           "requires": {
             "number-is-nan": "^1.0.0"
           }
@@ -2760,6 +2767,7 @@
           "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-3.0.4.tgz",
           "integrity": "sha512-yJHVQEhyqPLUTgt9B83PXu6W3rx4MvvHvSUvToogpwoGDOUQ+yDrR0HRot+yOCdCO7u4hX3pWft6kWBBcqh0UA==",
           "dev": true,
+          "optional": true,
           "requires": {
             "brace-expansion": "^1.1.7"
           }
@@ -2883,7 +2891,8 @@
           "version": "1.0.1",
           "resolved": "https://registry.npmjs.org/number-is-nan/-/number-is-nan-1.0.1.tgz",
           "integrity": "sha1-CXtgK1NCKlIsGvuHkDGDNpQaAR0=",
-          "dev": true
+          "dev": true,
+          "optional": true
         },
         "object-assign": {
           "version": "4.1.1",
@@ -3034,6 +3043,7 @@
           "resolved": "https://registry.npmjs.org/string-width/-/string-width-1.0.2.tgz",
           "integrity": "sha1-EYvfW4zcUaKn5w0hHgfisLmxB9M=",
           "dev": true,
+          "optional": true,
           "requires": {
             "code-point-at": "^1.0.0",
             "is-fullwidth-code-point": "^1.0.0",


### PR DESCRIPTION
On windows, because txt uses '\r\n' to start a newline instead of '\n', the original approach would actually add an extra '\r' at the end of the urls like ```https://alheimsins.net/\r```

Could you please test if this still works on Mac?

Update: Also fixed script terminating when url is invalid (because of [this line](https://github.com/zrrrzzt/html-validator/blob/master/index.js#L19)), and improved output