### PR TITLE
Added functionality to parse online files

### DIFF
--- a/lib/get-urls.js
+++ b/lib/get-urls.js
@@ -1,12 +1,18 @@
 'use strict'
 
 module.exports = async (options) => {
+  const urlsFromFileOnline = require('./helpers-get-urls/get-urls-from-file-online')
   const urlsFromCrawler = require('./helpers-get-urls/get-urls-from-crawler')
   const urlsFromFile = require('./helpers-get-urls/get-urls-from-file')
 
   var data
   if (options.file === false) {
-    data = await urlsFromCrawler(options.url, options.cacheTime, options.debug)
+    var fileType = options.url.toLowerCase().split('.').pop()
+    if (['txt', 'json', 'xml'].includes(fileType)) {
+      data = await urlsFromFileOnline(options.url, fileType, options.cacheTime)
+    } else {
+      data = await urlsFromCrawler(options.url, options.cacheTime, options.debug)
+    }
   } else {
     data = urlsFromFile(options.file)
   }

--- a/lib/helpers-get-urls/get-urls-from-crawler.js
+++ b/lib/helpers-get-urls/get-urls-from-crawler.js
@@ -1,13 +1,14 @@
 'use strict'
 
+const path = require('path')
+const clc = require('cli-color')
+const Cache = require('../Cache')
+const Crawler = require('simplecrawler')
+
 module.exports = (url, cacheTime, debug) => {
   return new Promise(async function (resolve, reject) {
     try {
-      const path = require('path')
-      const clc = require('cli-color')
       const urlHash = require('crypto').createHash('sha1').update(url).digest('hex')
-      const Cache = require('../Cache')
-      const Crawler = require('simplecrawler')
 
       var greenOnBlack = clc.xterm(47).bgXterm(0)
       var cachePath = path.resolve(`${__dirname}/../../cache/sitemap/`)

--- a/lib/helpers-get-urls/get-urls-from-file-online.js
+++ b/lib/helpers-get-urls/get-urls-from-file-online.js
@@ -1,0 +1,58 @@
+'use strict'
+
+const path = require('path')
+const https = require('https')
+const clc = require('cli-color')
+const parseFile = require('./parse-file')
+const Cache = require('../Cache')
+
+module.exports = (url, fileType, cacheTime) => {
+  return new Promise(async function (resolve, reject) {
+    const urlHash = require('crypto').createHash('sha1').update(url).digest('hex')
+
+    var greenOnBlack = clc.xterm(47).bgXterm(0)
+    var cachePath = path.resolve(`${__dirname}/../../cache/sitemap/`)
+    var cache = new Cache(urlHash, cachePath, cacheTime)
+    var cacheOld = cache.getKey(url)
+
+    if (cacheTime !== 0 && cacheOld !== undefined) {
+      console.log('\n' + greenOnBlack('Success') + ` Online File Cache found for ${url}`)
+      console.log('\n' + 'Pages found in cache')
+      cacheOld.forEach(e => { console.log(greenOnBlack(e)) })
+      return resolve(cacheOld)
+    } else {
+      console.log(`\nFetching ${url} ...`)
+
+      /*
+      https://www.twilio.com/blog/2017/08/http-requests-in-node-js.html
+       */
+      var data = ''
+      https.get(url, (resp) => {
+        var status = resp.statusCode
+        resp.on('data', (chunk) => {
+          data += chunk
+        })
+        resp.on('end', () => {
+          try {
+            if (status !== 200) {
+              throw new Error(`Server responded with status code ${status}`)
+            }
+            console.log('\nFile fetched successfully')
+            var urls = parseFile(fileType, data)
+            if (cacheTime !== 0) {
+              cache.setKey(url, urls)
+              cache.save()
+            }
+            console.log('\n' + 'Pages found:')
+            urls.forEach(e => { console.log(greenOnBlack(e)) })
+            return resolve(urls)
+          } catch (error) {
+            reject(error)
+          }
+        })
+      }).on('error', (error) => {
+        reject(error)
+      })
+    }
+  })
+}

--- a/lib/helpers-get-urls/get-urls-from-file.js
+++ b/lib/helpers-get-urls/get-urls-from-file.js
@@ -1,46 +1,15 @@
 'use strict'
 
 const { readFileSync } = require('fs')
-const xmlParser = require('fast-xml-parser')
+const clc = require('cli-color')
+const parseFile = require('./parse-file')
 
 module.exports = path => {
-  const clc = require('cli-color')
   const fileType = path.toLowerCase().split('.').pop()
   const data = readFileSync(path, 'utf-8').toString()
 
   var greenOnBlack = clc.xterm(47).bgXterm(0)
-  var urls
-
-  if (fileType !== 'json' && fileType !== 'txt' && fileType !== 'xml') {
-    throw new Error('Unallowed file type')
-  } else if (fileType === 'json') {
-    try {
-      urls = JSON.parse(data)
-    } catch (error) {
-      throw new Error('Invalid JSON')
-    }
-    if (!Array.isArray(urls)) {
-      throw new Error('Unallowed JSON format')
-    }
-  } else if (fileType === 'txt') {
-    urls = data.split(/\r?\n/).filter(url => url.trim() !== '')
-  } else {
-    try {
-      var json = xmlParser.parse(data)
-    } catch (error) {
-      throw new Error('Invalid XML')
-    }
-    try {
-      if (json.urlset.url.length === 1 || json.urlset.url.length === undefined) {
-        urls = [json.urlset.url.loc]
-      } else {
-        urls = json.urlset.url.map(o => { return o.loc })
-      }
-      urls = urls.filter(url => !/(\.pdf)$/i.test(url))
-    } catch (error) {
-      throw new Error('Unallowed XML format')
-    }
-  }
+  var urls = parseFile(fileType, data)
 
   console.log('\n' + 'Pages found:')
   urls.forEach(e => { console.log(greenOnBlack(e)) })

--- a/lib/helpers-get-urls/parse-file.js
+++ b/lib/helpers-get-urls/parse-file.js
@@ -1,0 +1,38 @@
+'use strict'
+
+const xmlParser = require('fast-xml-parser')
+
+module.exports = (fileType, data) => {
+  var urls
+  if (fileType !== 'json' && fileType !== 'txt' && fileType !== 'xml') {
+    throw new Error('Unallowed file type')
+  } else if (fileType === 'json') {
+    try {
+      urls = JSON.parse(data)
+    } catch (error) {
+      throw new Error('Invalid JSON')
+    }
+    if (!Array.isArray(urls)) {
+      throw new Error('Unallowed JSON format')
+    }
+  } else if (fileType === 'txt') {
+    urls = data.split(/\r?\n/).filter(url => url.trim() !== '')
+  } else {
+    try {
+      var json = xmlParser.parse(data)
+    } catch (error) {
+      throw new Error('Invalid XML')
+    }
+    try {
+      if (json.urlset.url.length === 1 || json.urlset.url.length === undefined) {
+        urls = [json.urlset.url.loc]
+      } else {
+        urls = json.urlset.url.map(o => { return o.loc })
+      }
+      urls = urls.filter(url => !/(\.pdf)$/i.test(url))
+    } catch (error) {
+      throw new Error('Unallowed XML format')
+    }
+  }
+  return urls
+}


### PR DESCRIPTION
If the url ends with ```txt```/```json```/```xml```, will try to fetch those and parse them as file, instead of crawling.
This is especially useful for sites that already has a ```sitemap.xml``` hosted (way quicker than crawling)

Example:
```
$ site-validator https://raw.githubusercontent.com/p1ho/site-validator-cli/master/test/data/urls.txt
```

Because of this addition, I modularized the file parsing process, which should be easy to test.