### PR TITLE
Implements p-queue to enable concurrent validations (minor)

### DIFF
--- a/lib/helpers-validate-pages/get-result.js
+++ b/lib/helpers-validate-pages/get-result.js
@@ -4,10 +4,8 @@ module.exports = async (url, cache = undefined, cacheTime = false) => {
   const validator = require('html-validator')
 
   if (cache !== undefined && cacheTime !== false && cache.getKey(url) !== undefined) {
-    console.log('\nPage validation cache found!')
     return JSON.parse(cache.getKey(url))
   } else {
-    console.log('\nValidating...')
     let data = await validator({ url: url })
     if (cache !== undefined) { cache.setKey(url, data) }
     return JSON.parse(data)

--- a/lib/validate-pages.js
+++ b/lib/validate-pages.js
@@ -1,16 +1,7 @@
 'use strict'
 
-/*
-Making async work as intended in a forEach loop.
-https://codeburst.io/javascript-async-await-with-foreach-b6ba62bbf404
- */
-async function asyncForEach (array, callback) {
-  for (let index = 0; index < array.length; index++) {
-    await callback(array[index], index, array)
-  }
-}
-
 module.exports = async (pagesToValidate, options) => {
+  const PQueue = require('p-queue')
   const path = require('path')
   const pagesHash = require('crypto').createHash('sha1').update(pagesToValidate.join('_')).digest('hex')
   const Cache = require('./Cache')
@@ -28,13 +19,13 @@ module.exports = async (pagesToValidate, options) => {
 
   let pagesTotal = pagesToValidate.length
   console.log(`\nEvaluating a total of ${pagesTotal} pages`)
+  console.log('__________________________________\n')
 
+  const queue = new PQueue({ concurrency: 3 })
   let pagesNotFound = []
   let pagesFail = []
 
-  asyncForEach(pagesToValidate, async (page, i) => {
-    console.log('__________________________________')
-    console.log(`\nChecking page ${i + 1} of ${pagesTotal} pages`)
+  const validatePage = async page => {
     try {
       let result = await getResult(page, cache, options.cacheTime)
 
@@ -58,7 +49,12 @@ module.exports = async (pagesToValidate, options) => {
     } catch (error) {
       console.log([redOnBlack(error), page].join(' '))
     }
-  }).then(() => {
+    return true
+  }
+
+  pagesToValidate.map(page => queue.add(async () => validatePage(page)))
+
+  queue.onIdle().then(() => {
     if (useCache) { cache.save() }
     console.log('__________________________________')
     printFinish(options.path, pagesTotal, pagesNotFound, pagesFail)

--- a/package.json
+++ b/package.json
@@ -19,6 +19,7 @@
     "html-validator": "3.1.3",
     "minimist": "1.2.0",
     "normalize-url": "4.1.0",
+    "p-queue": "4.0.0",
     "simplecrawler": "1.1.6"
   },
   "devDependencies": {


### PR DESCRIPTION
To help speed up things I've added [p-queue](https://github.com/sindresorhus/p-queue)

At the moment concurrency is set to 3. In time we might consider that to be adjusted from input flags.

Had to remove some of the logging due to a bit strange output given async execution.