### PR TITLE
Removed Deploy workflow

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -3,10 +3,3 @@ node_js:
   - "10"
 after_success:
   - npm run coveralls
-deploy:
-  provider: npm
-  email: $NPM_EMAIL
-  api_key: $NPM_TOKEN
-  on:
-    tags: true
-    branch: master


### PR DESCRIPTION
Deploy using Travis will fail because it requires manual authorization, taking the workflow out